### PR TITLE
Introduce stricter types

### DIFF
--- a/src/platform/Module.tsx
+++ b/src/platform/Module.tsx
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === "development") {
     enablePatches();
 }
 
-export interface ModuleLifecycleListener<RouteParam extends {} = {}> {
+export interface ModuleLifecycleListener<RouteParam extends object = object> {
     onEnter: ((routeParameters: RouteParam) => SagaIterator) & LifecycleDecoratorFlag;
     onDestroy: (() => SagaIterator) & LifecycleDecoratorFlag;
     onTick: (() => SagaIterator) & LifecycleDecoratorFlag & TickIntervalDecoratorFlag;
@@ -19,7 +19,7 @@ export interface ModuleLifecycleListener<RouteParam extends {} = {}> {
     onBlur: (() => SagaIterator) & LifecycleDecoratorFlag;
 }
 
-export class Module<RootState extends State, ModuleName extends keyof RootState["app"] & string, RouteParam extends {} = {}> implements ModuleLifecycleListener<RouteParam> {
+export class Module<RootState extends State, ModuleName extends keyof RootState["app"] & string, RouteParam extends object = object> implements ModuleLifecycleListener<RouteParam> {
     constructor(readonly name: ModuleName, readonly initialState: RootState["app"][ModuleName]) {}
 
     *onEnter(routeParameters: RouteParam): SagaIterator {

--- a/src/platform/Module.tsx
+++ b/src/platform/Module.tsx
@@ -87,11 +87,12 @@ export class Module<RootState extends State, ModuleName extends keyof RootState[
             const originalState = this.state;
             const updater = stateOrUpdater as (state: RootState["app"][ModuleName]) => void;
             let patchDescriptions: string[] | undefined;
-            const newState = produce(
+            // TS cannot infer RootState["app"][ModuleName] as an object, so immer fails to unwrap the readonly type with Draft<T>
+            const newState = produce<Readonly<RootState["app"][ModuleName]>, RootState["app"][ModuleName]>(
                 originalState,
                 (draftState) => {
                     // Wrap into a void function, in case updater() might return anything
-                    updater(draftState as any);
+                    updater(draftState);
                 },
                 process.env.NODE_ENV === "development"
                     ? (patches) => {

--- a/src/platform/ModuleProxy.tsx
+++ b/src/platform/ModuleProxy.tsx
@@ -13,7 +13,7 @@ export class ModuleProxy<M extends Module<any, any>> {
         return this.actions;
     }
 
-    attachLifecycle<P extends {}>(ComponentType: React.ComponentType<P>): React.ComponentType<P> {
+    attachLifecycle<P extends object>(ComponentType: React.ComponentType<P>): React.ComponentType<P> {
         const moduleName = this.module.name;
         const lifecycleListener = this.module as ModuleLifecycleListener;
         const actions = this.actions as any;

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -7,7 +7,7 @@ interface LoadingState {
 
 export interface State {
     loading: LoadingState;
-    app: {};
+    app: object;
 }
 
 // Redux Action

--- a/src/typed-saga.ts
+++ b/src/typed-saga.ts
@@ -1,7 +1,5 @@
 import {StrictEffect, call as rawCall, Effect, race as rawRace, spawn, all as rawAll, delay, put} from "redux-saga/effects";
 
-type StrictObject<T extends {}> = T extends any[] ? never : T;
-
 type SagaGenerator<RT> = Generator<Effect<any>, RT, any>;
 
 type UnwrapReturnType<R> = R extends SagaGenerator<infer RT> ? RT : R extends Promise<infer PromiseValue> ? PromiseValue : R;
@@ -12,11 +10,11 @@ export function* call<Args extends any[], R>(fn: (...args: Args) => R, ...args: 
     return yield rawCall(fn, ...args);
 }
 
-export function* race<T extends {}>(effects: StrictObject<T>): SagaGenerator<{[P in keyof T]?: UnwrapReturnType<T[P]>}> {
+export function* race<T extends Record<string, unknown>>(effects: T): SagaGenerator<{[P in keyof T]?: UnwrapReturnType<T[P]>}> {
     return yield rawRace(effects);
 }
 
-export function* all<T extends {}>(effects: StrictObject<T>): SagaGenerator<{[P in keyof T]: UnwrapReturnType<T[P]>}> {
+export function* all<T extends Record<string, unknown>>(effects: T): SagaGenerator<{[P in keyof T]: UnwrapReturnType<T[P]>}> {
     return yield rawAll(effects);
 }
 

--- a/test/typed-saga.test.ts
+++ b/test/typed-saga.test.ts
@@ -1,35 +1,125 @@
-import {call} from "../src/typed-saga";
-import {call as rawCall} from "redux-saga/effects";
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 
-interface APIResponse {
-    foo: number;
-}
+import {all, call, race} from "../src/typed-saga";
+import {call as rawCall, delay} from "redux-saga/effects";
 
-async function fetchAPI(value: number): Promise<APIResponse> {
-    return {foo: value * 2};
-}
-
-test("typed saga call", () => {
-    function* saga() {
-        const apiResult = yield* call(fetchAPI, 50);
-        yield apiResult;
+describe("typed-saga (functional test)", () => {
+    interface APIResponse {
+        foo: number;
     }
-    const sagaGenerator = saga();
 
-    const firstYield = sagaGenerator.next();
-    const callEffect = rawCall(fetchAPI, 50);
-    expect(firstYield.done).toBe(false);
-    expect(firstYield.value).toEqual(callEffect);
+    async function fetchAPI(value: number): Promise<APIResponse> {
+        return {foo: value * 2};
+    }
 
-    /**
-     * Must pass parameter to next() to mock the whole saga workflow
-     * Ref: https://redux-saga.js.org/docs/advanced/Testing.html
-     */
-    const secondYield = sagaGenerator.next({foo: 100});
-    expect(secondYield.done).toBe(false);
-    expect(secondYield.value).toEqual({foo: 100});
+    test("typed saga call", () => {
+        function* saga() {
+            const apiResult = yield* call(fetchAPI, 50);
+            yield apiResult;
+        }
+        const sagaGenerator = saga();
 
-    const thirdYield = sagaGenerator.next();
-    expect(thirdYield.done).toBe(true);
-    expect(thirdYield.value).toBeUndefined();
+        const firstYield = sagaGenerator.next();
+        const callEffect = rawCall(fetchAPI, 50);
+        expect(firstYield.done).toBe(false);
+        expect(firstYield.value).toEqual(callEffect);
+
+        /**
+         * Must pass parameter to next() to mock the whole saga workflow
+         * Ref: https://redux-saga.js.org/docs/advanced/Testing.html
+         */
+        const secondYield = sagaGenerator.next({foo: 100});
+        expect(secondYield.done).toBe(false);
+        expect(secondYield.value).toEqual({foo: 100});
+
+        const thirdYield = sagaGenerator.next();
+        expect(thirdYield.done).toBe(true);
+        expect(thirdYield.value).toBeUndefined();
+    });
+});
+
+describe("typed-saga (type test)", () => {
+    describe("race", () => {
+        test("should accept an object as parameter", () => {
+            race({});
+            race({d1: delay(1), d2: delay(2)});
+            function* unimportantGeneratorUsedForTypeTestingOnly() {
+                const {c1, c2, c3} = yield* race({
+                    c1: call(async (_: number): Promise<number> => _, 1),
+                    c2: call(async (_: string): Promise<string> => _, "s"),
+                    c3: call(async (_: {foo: number; bar: string}): Promise<{baz: boolean}> => ({baz: true}), {foo: 0, bar: ""}),
+                    d: delay(10),
+                });
+                const expectC1ToBeAssignableToType: number | undefined = c1;
+                const expectC2ToBeAssignableToType: string | undefined = c2;
+                const expectC3ToBeAssignableToType: {baz: boolean} | undefined = c3;
+            }
+        });
+
+        test("should not accept an array as parameter", () => {
+            // @ts-expect-error
+            race([]);
+            // @ts-expect-error
+            race([delay(1), delay(2)]);
+            // @ts-expect-error
+            race([call(async (_: number): Promise<number> => _, 1), delay(10)]);
+        });
+
+        test("should not accept any primitive values as parameter (regression test for `{}` typing)", () => {
+            // @ts-expect-error
+            race(undefined);
+            // @ts-expect-error
+            race(null);
+            // @ts-expect-error
+            race(1);
+            // @ts-expect-error
+            race(true);
+            // @ts-expect-error
+            race("string");
+            // @ts-expect-error
+            race(Symbol.for("symbol"));
+        });
+    });
+
+    describe("all", () => {
+        test("should accept an object as parameter", () => {
+            all({});
+            all({d1: delay(1), d2: delay(2)});
+            function* unimportantGeneratorUsedForTypeTestingOnly() {
+                const {c1, c2, c3} = yield* all({
+                    c1: call(async (_: number): Promise<number> => _, 1),
+                    c2: call(async (_: string): Promise<string> => _, "s"),
+                    c3: call(async (_: {foo: number; bar: string}): Promise<{baz: boolean}> => ({baz: true}), {foo: 0, bar: ""}),
+                    d: delay(10),
+                });
+                const expectC1ToBeAssignableToType: number = c1;
+                const expectC2ToBeAssignableToType: string = c2;
+                const expectC3ToBeAssignableToType: {baz: boolean} = c3;
+            }
+        });
+
+        test("should not accept an array as parameter", () => {
+            // @ts-expect-error
+            all([]);
+            // @ts-expect-error
+            all([delay(1), delay(2)]);
+            // @ts-expect-error
+            all([call(async (_: number): Promise<number> => _, 1), delay(10)]);
+        });
+
+        test("should not accept any primitive values as parameter (regression test for `{}` typing)", () => {
+            // @ts-expect-error
+            all(undefined);
+            // @ts-expect-error
+            all(null);
+            // @ts-expect-error
+            all(1);
+            // @ts-expect-error
+            all(true);
+            // @ts-expect-error
+            all("string");
+            // @ts-expect-error
+            all(Symbol.for("symbol"));
+        });
+    });
 });


### PR DESCRIPTION
This PR introduces stricter typing by:
- Replacing instances of `{}` (non-nullish type) with `object` (actual object type) where the types should be an actual object
- Remove the `as any` used by `immer.produce` by explicitly annotating the generic types since type inference failed to work properly
- Fix `race`, `all` generic types, and emits type error during compilation time when parameter type is invalid

More details can be found in the individual commit messages