### PR TITLE
save original error in the JavaScriptException

### DIFF
--- a/src/Exception.ts
+++ b/src/Exception.ts
@@ -19,7 +19,7 @@ export class NetworkConnectionException extends Exception {
 }
 
 export class JavaScriptException extends Exception {
-    constructor(message: string) {
+    constructor(message: string, public originalError?: any) {
         super(message);
     }
 }

--- a/src/util/error-util.ts
+++ b/src/util/error-util.ts
@@ -30,7 +30,7 @@ export function errorToException(error: unknown): Exception {
                 message = "[Unknown]";
             }
         }
-        return new JavaScriptException(message);
+        return new JavaScriptException(message, error);
     }
 }
 


### PR DESCRIPTION
The main purpose is to report the error to some service like Bugsnag, so that we can use Bugsnag to show the source line number of error.